### PR TITLE
fix(cgl): only reset composer.lock when it is tracked by git

### DIFF
--- a/.github/workflows/cgl-test.yml
+++ b/.github/workflows/cgl-test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check dependencies
         run: composer-require-checker check
       - name: Reset composer.json
-        run: git checkout composer.json $(test -e composer.lock && echo composer.lock)
+        run: git checkout composer.json $(git ls-files --error-unmatch composer.lock >/dev/null 2>&1 && echo composer.lock)
       - name: Re-install Composer dependencies
         uses: ramsey/composer-install@v4
       - name: Check for unused dependencies

--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check dependencies
         run: composer-require-checker check
       - name: Reset composer.json
-        run: git checkout composer.json $(test -e composer.lock && echo composer.lock)
+        run: git checkout composer.json $(git ls-files --error-unmatch composer.lock >/dev/null 2>&1 && echo composer.lock)
       - name: Re-install Composer dependencies
         uses: ramsey/composer-install@v4
       - name: Check for unused dependencies


### PR DESCRIPTION
## Summary

- The CGL workflows reset `composer.json` (and `composer.lock`) after the `composer-require-checker` step. The guard used `test -e composer.lock`, which checks the **filesystem**.
- For library repos that gitignore `composer.lock`, `composer install` creates the file on disk, so the guard passes — but `git checkout composer.lock` then fails with `pathspec 'composer.lock' did not match any file(s) known to git`, breaking the job.

## Fix

Guard on whether git **tracks** the file instead of whether it exists on disk:

```
git checkout composer.json $(git ls-files --error-unmatch composer.lock >/dev/null 2>&1 && echo composer.lock)
```

- App repos (lock committed) → `composer.lock` is restored, as before.
- Library repos (lock gitignored) → only `composer.json` is restored, no failure.

## Changes

- `.github/workflows/cgl.yml`
- `.github/workflows/cgl-test.yml`