### PR TITLE
fix(cgl): refresh composer.lock hash before linting

### DIFF
--- a/.github/workflows/cgl-test.yml
+++ b/.github/workflows/cgl-test.yml
@@ -45,6 +45,8 @@ jobs:
         run: composer-unused
 
       # Linting
+      - name: Refresh composer.lock hash
+        run: composer update --lock
       - name: Lint composer.json
         run: composer cgl lint:composer
       - name: Lint Editorconfig

--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -45,6 +45,8 @@ jobs:
         run: composer-unused
 
       # Linting
+      - name: Refresh composer.lock hash
+        run: composer update --lock
       - name: Lint composer.json
         run: composer lint:composer
       - name: Lint Editorconfig


### PR DESCRIPTION
## Summary

- After the `composer-require-checker` dance (`composer require composer/composer` → reset `composer.json`), the on-disk `composer.lock` is left out of sync with `composer.json` whenever the lock is **not** restored — i.e. in library repos that gitignore `composer.lock`.
- `composer normalize` (run via `lint:composer`) then fails with *"The lock file is not up to date with the latest changes in composer.json"*, breaking the job.

## Fix

Re-add a `composer update --lock` step before the linting stage. This only refreshes the lock's content hash to match `composer.json` (no dependency version changes), making the lint stage pass for both app and library repos.

## Changes

- `.github/workflows/cgl.yml`
- `.github/workflows/cgl-test.yml`