### PR TITLE
feat: harden CI permissions and add security/scorecard workflows

### DIFF
--- a/.github/workflows/cgl-test.yml
+++ b/.github/workflows/cgl-test.yml
@@ -8,6 +8,9 @@ on:
         default: '8.2'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   cgl:
     runs-on: ubuntu-latest

--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -8,6 +8,9 @@ on:
         default: '8.2'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   cgl:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-typo3.yml
+++ b/.github/workflows/release-typo3.yml
@@ -21,6 +21,9 @@ env:
   TYPO3_EXCLUDE_FROM_PACKAGING: packaging_exclude.php
   EXTENSION_ARTEFACT: ${{ inputs.typo3-extension-key }}_${{ github.ref_name }}.zip
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build extension artefact
@@ -77,6 +80,8 @@ jobs:
     name: Create release
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create GitHub release
     outputs:
       release-notes-url: ${{ steps.create-release.outputs.url }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,15 @@ name: Release
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create GitHub release
     outputs:
       release-notes-url: ${{ steps.create-release.outputs.url }}
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: OpenSSF Scorecard
+
+# Supply-chain posture scoring (branch protection, pinned actions, token
+# permissions, ...). Runs on default-branch push and weekly; results upload to
+# the code-scanning dashboard and publish the public Scorecard badge.
+# Dual-trigger: runs on this repo directly and is callable as a reusable
+# workflow by consumers (which supply their own push/schedule triggers).
+
+on:
+  workflow_call:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scorecard:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code-scanning
+      id-token: write # publish results to OpenSSF
+      actions: read # read workflow run data for checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,30 @@
+name: Security
+
+# Secret scanning (gitleaks). gitleaks-action is free for public/personal
+# repositories, so no GITLEAKS_LICENSE is required here. Dual-trigger: runs on
+# this repo directly and is callable as a reusable workflow by consumers.
+
+on:
+  workflow_call:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  gitleaks:
+    name: Secret scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -14,6 +14,9 @@ on:
         default: '["highest", "lowest"]'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests (PHP ${{ matrix.php-version }} & ${{ matrix.dependencies }} dependencies)

--- a/.github/workflows/tests-typo3.yml
+++ b/.github/workflows/tests-typo3.yml
@@ -19,6 +19,9 @@ on:
         default: '["highest", "lowest"]'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }} & ${{ matrix.dependencies }} dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ on:
         default: '["highest", "lowest"]'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }} & ${{ matrix.dependencies }} dependencies

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![License](https://img.shields.io/github/license/konradmichalik/reusable-github-actions)](LICENSE)
 [![Workflows](https://img.shields.io/badge/workflows-8-green)]()
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/konradmichalik/reusable-github-actions/badge)](https://securityscorecards.dev/viewer/?uri=github.com/konradmichalik/reusable-github-actions)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Reusable GitHub Actions
 
 [![License](https://img.shields.io/github/license/konradmichalik/reusable-github-actions)](LICENSE)
-[![Workflows](https://img.shields.io/badge/workflows-6-green)]()
+[![Workflows](https://img.shields.io/badge/workflows-8-green)]()
 
 </div>
 
@@ -20,6 +20,8 @@ This repository provides useful GitHub Action workflows.
 - [Tests TYPO3](#tests-typo3)
 - [Release](#release)
 - [Release TYPO3](#release-typo3)
+- [Security](#security)
+- [OpenSSF Scorecard](#openssf-scorecard)
 
 ## CGL
 
@@ -146,7 +148,12 @@ on:
 jobs:
   release:
         uses: konradmichalik/reusable-github-actions/.github/workflows/release.yml@main
+        permissions:
+          contents: write
 ```
+
+> [!NOTE]
+> The caller job must grant `contents: write` so the reusable can create the GitHub release. This is only required explicitly if the repository's default workflow token is set to read-only (recommended hardening).
 
 ## Release TYPO3
 
@@ -163,17 +170,68 @@ on:
 jobs:
   release:
         uses: konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main
+        permissions:
+          contents: write
         secrets:
           typo3-api-token: ${{ secrets.TYPO3_API_TOKEN }}
         with:
           typo3-extension-key: 'your_extension_key'
 ```
 
+> [!NOTE]
+> The caller job must grant `contents: write` so the reusable can create the GitHub release. This is only required explicitly if the repository's default workflow token is set to read-only (recommended hardening).
+
 Input|Type| Required |Description
 -|-|----------|-
 `typo3-extension-key`|input| true    |TYPO3 extension key (as used in TER and GitHub repository name).
 `vendor-bundling`|input| false    |Bundle non-TYPO3 vendor libraries for classic mode before packaging. Requires `eliashaeussler/typo3-vendor-bundler` in `require-dev` and a `bundle` composer script. Defaults to `false`.
 `typo3-api-token`|secret| true    |TYPO3 API token with permission to upload to TER.
+
+## Security
+
+Secret scanning via [gitleaks](https://github.com/gitleaks/gitleaks). Runs on pushes and pull requests and fails the job if secrets are detected. Free for public and personal repositories (no `GITLEAKS_LICENSE` required).
+
+```yaml
+name: Security
+on:
+  push:
+    branches:
+      - main
+  pull_request: ~
+
+jobs:
+  security:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+```
+
+## OpenSSF Scorecard
+
+Supply-chain posture scoring via [OpenSSF Scorecard](https://github.com/ossf/scorecard) (branch protection, pinned actions, token permissions and more). Results are uploaded to the repository's code scanning dashboard.
+
+> [!NOTE]
+> Requires **Code Scanning** available (Settings → Advanced Security → Code scanning) for the SARIF upload — free on public repositories, needs GitHub Advanced Security on private ones. The published Scorecard badge requires a public repository.
+
+```yaml
+name: OpenSSF Scorecard
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  scorecard:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+```
 
 ## ⭐ License
 


### PR DESCRIPTION
## Summary

- Add least-privilege \`permissions\` to all existing reusable workflows (default-deny is now explicit at every call site)
- Add two new dual-trigger reusable workflows: gitleaks secret scanning and OpenSSF Scorecard supply-chain scoring
- Document the new workflows and the \`contents: write\` requirement for release callers

## Changes

- \`.github/workflows/{cgl,cgl-test,tests,tests-php,tests-typo3}.yml\` - top-level \`contents: read\` (read-only jobs)
- \`.github/workflows/{release,release-typo3}.yml\` - \`contents: read\` default, \`contents: write\` only on the release job
- \`.github/workflows/security.yml\` - new gitleaks secret scanning, callable via \`workflow_call\`
- \`.github/workflows/scorecard.yml\` - new OpenSSF Scorecard, callable via \`workflow_call\`
- \`README.md\` - new Security and OpenSSF Scorecard sections, workflow badge 6→8, release permission notes

## Notes

- Consumers of \`cgl\`/\`tests\` need no changes (read scope is transparent).
- Release callers must grant \`contents: write\` explicitly once the repo default token is set to read-only.
- Scorecard SARIF upload requires Code Scanning (Settings → Advanced Security), free on public repositories.