### PR TITLE
fix: pin ossf/scorecard-action to a resolvable release commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- \`ossf/scorecard-action\` does not publish a floating \`v2\` major tag (only fully-qualified \`vX.Y.Z\` tags), so \`@v2\` fails to resolve at workflow run time
- Pin to the commit SHA of the latest release (\`v2.4.3\`) instead, with the version noted in a trailing comment for readability

## Changes

- \`.github/workflows/scorecard.yml\` - \`ossf/scorecard-action@v2\` → \`ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3\`