### PR TITLE
fix: use dereferenced commit SHA for ossf/scorecard-action pin

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- The prior pin (\`99c09fe975337306107572b4fdf4db224cf8e2f2\`) was the **tag object** SHA of the annotated tag \`v2.4.3\`, not the underlying commit
- Scorecard's publish step verifies the pinned SHA against real commits in \`ossf/scorecard-action\` and rejected the tag-object SHA as an "imposter commit", so results never reached the OpenSSF webapp (analysis itself succeeded, only publishing failed)
- Dereferenced the tag object to the actual commit SHA (\`4eaacf0543bb3f2c246792bd56e8cdeffafb205a\`)

## Changes

- \`.github/workflows/scorecard.yml\` - \`ossf/scorecard-action@99c09fe...\` → \`ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3\`