### PR TITLE
fix: replace gitleaks-action wrapper with direct CLI invocation

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,12 @@
 name: Security
 
-# Secret scanning (gitleaks). gitleaks-action is free for public/personal
-# repositories, so no GITLEAKS_LICENSE is required here. Dual-trigger: runs on
-# this repo directly and is callable as a reusable workflow by consumers.
+# Secret scanning via the gitleaks CLI, invoked directly from its official
+# Docker image rather than the gitleaks/gitleaks-action wrapper. The wrapper
+# requires a paid GITLEAKS_LICENSE for any GitHub Organization (regardless of
+# repo visibility) — the underlying gitleaks scanner itself is fully open
+# source and free, so calling it directly avoids that paywall for org-owned
+# consumers of this reusable. Dual-trigger: runs on this repo directly and is
+# callable as a reusable workflow by consumers.
 
 on:
   workflow_call:
@@ -25,6 +29,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker://zricethezav/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f # v8.30.1
+        with:
+          args: detect --source=/github/workspace --verbose --redact --exit-code=1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,5 +30,13 @@ jobs:
 
       - name: Run gitleaks
         uses: docker://zricethezav/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f # v8.30.1
+        env:
+          # The container's git sees /github/workspace as owned by a different
+          # UID than it runs as and refuses to touch it ("dubious ownership")
+          # unless explicitly marked safe — without this, gitleaks silently
+          # scans 0 commits and reports a false "no leaks found".
+          GIT_CONFIG_COUNT: '1'
+          GIT_CONFIG_KEY_0: safe.directory
+          GIT_CONFIG_VALUE_0: /github/workspace
         with:
           args: detect --source=/github/workspace --verbose --redact --exit-code=1


### PR DESCRIPTION
## Summary

- \`gitleaks/gitleaks-action\` requires a paid \`GITLEAKS_LICENSE\` for any GitHub Organization, regardless of repository visibility — this broke \`security.yml\` for every org-owned consumer (xima-media, move-elevator), while personal-account consumers were unaffected
- The underlying gitleaks scanner itself is fully open source and free; invoking its official Docker image directly removes the wrapper's licensing gate entirely
- Bonus: also sidesteps gitleaks-action's Node 20 deprecation (GitHub Actions removes Node 20 support in Sept 2026) since this is now a plain Docker container step, not a Node-based action

## Changes

- \`.github/workflows/security.yml\` - replaced \`uses: gitleaks/gitleaks-action@v2\` with \`uses: docker://zricethezav/gitleaks@sha256:c00b...\` (pinned to v8.30.1), calling \`gitleaks detect\` directly

## Test plan

- [x] Verify this PR's own CI run (pull_request trigger fires directly on this repo) shows a passing gitleaks scan
- [ ] After merge, re-run \`security.yml\` on an org-owned consumer (xima-media/move-elevator) to confirm no \`GITLEAKS_LICENSE\` error
