### PR TITLE
fix: skip reusable workflows on unsupported caller refs

### DIFF
--- a/.github/workflows/release-typo3.yml
+++ b/.github/workflows/release-typo3.yml
@@ -27,6 +27,11 @@ permissions:
 jobs:
   build:
     name: Build extension artefact
+    # Releases run from tags only. Skip cleanly (neutral, not failed) if a caller
+    # triggers this on a non-tag ref, matching release.yml's guard. Downstream
+    # jobs `need` this one, so they skip with it. The subsequent step still
+    # validates the exact N.N.N tag format for real tag runs.
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,16 @@ jobs:
   scorecard:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # scorecard-action only supports the default branch and hard-fails on any
+    # other ref ("only default branch is supported"). A careless caller trigger
+    # (e.g. push: branches: ['**']) would otherwise put a guaranteed-red check
+    # on every feature-branch push. Skip cleanly (neutral, not failed) unless we
+    # are on the default branch, a schedule, or a manual dispatch. The github
+    # context here is the caller's, so default_branch resolves to the caller repo.
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_name == github.event.repository.default_branch
     permissions:
       contents: read
       security-events: write # upload SARIF to code-scanning

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ Supply-chain posture scoring via [OpenSSF Scorecard](https://github.com/ossf/sco
 > [!NOTE]
 > Requires **Code Scanning** available (Settings → Advanced Security → Code scanning) for the SARIF upload — free on public repositories, needs GitHub Advanced Security on private ones. The published Scorecard badge requires a public repository.
 
+> [!IMPORTANT]
+> Trigger this workflow **only on the default branch**, on a schedule, and via manual dispatch — as shown below. The `scorecard-action` supports the default branch only and hard-fails on any other ref, so a wildcard trigger such as `push: branches: ['**']` would add a guaranteed-red check to every feature-branch push. The reusable now skips itself (neutral, not failed) on non-default branches as a safety net, but using the recommended trigger avoids the unnecessary runs entirely.
+
 ```yaml
 name: OpenSSF Scorecard
 on:


### PR DESCRIPTION
## Summary

- Guard the OpenSSF Scorecard job so it is **skipped (neutral, not failed)** on non-default branches (schedules and manual dispatch aside). `scorecard-action` only supports the default branch and hard-fails on any other ref, so a wildcard caller trigger (e.g. `push: branches: ['**']`) previously put a guaranteed-red check on every feature-branch push.
- Apply the same defensive pattern to the TYPO3 release build job, which had the same latent issue: a non-tag caller trigger hard-failed at the tag-format check instead of skipping. Now aligned with `release.yml`'s existing `if: startsWith(github.ref, 'refs/tags/')` guard; downstream jobs `need` it and skip with it.
- Document the recommended Scorecard caller trigger in the README with an explicit warning against wildcard branch triggers.

The guard uses the caller-inherited `github` context, so `github.event.repository.default_branch` resolves to the caller repo. Existing callers need no changes and benefit immediately.

## Changes

- `.github/workflows/scorecard.yml` — job-level `if` guard skipping non-default-branch runs
- `.github/workflows/release-typo3.yml` — job-level `if` guard skipping non-tag runs
- `README.md` — document recommended Scorecard trigger + warning