### PR TITLE
chore(ci): add actionlint, zizmor and shellcheck to this repository's own CI

### DIFF
--- a/.github/workflows/cgl-test.yml
+++ b/.github/workflows/cgl-test.yml
@@ -41,7 +41,12 @@ jobs:
       - name: Check dependencies
         run: composer-require-checker check
       - name: Reset composer.json
-        run: git checkout composer.json $(git ls-files --error-unmatch composer.lock >/dev/null 2>&1 && echo composer.lock)
+        run: |
+          if git ls-files --error-unmatch composer.lock >/dev/null 2>&1; then
+            git checkout composer.json composer.lock
+          else
+            git checkout composer.json
+          fi
       - name: Re-install Composer dependencies
         uses: ramsey/composer-install@v4
       - name: Check for unused dependencies

--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -41,7 +41,12 @@ jobs:
       - name: Check dependencies
         run: composer-require-checker check
       - name: Reset composer.json
-        run: git checkout composer.json $(git ls-files --error-unmatch composer.lock >/dev/null 2>&1 && echo composer.lock)
+        run: |
+          if git ls-files --error-unmatch composer.lock >/dev/null 2>&1; then
+            git checkout composer.json composer.lock
+          else
+            git checkout composer.json
+          fi
       - name: Re-install Composer dependencies
         uses: ramsey/composer-install@v4
       - name: Check for unused dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Run actionlint
+        run: actionlint
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: pip install zizmor==1.29.0
+
+      - name: Run zizmor
+        run: zizmor .github/workflows/
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run shellcheck
+        run: |
+          if ls scripts/*.sh >/dev/null 2>&1; then
+            shellcheck -s sh scripts/*.sh
+          else
+            echo "no scripts/*.sh yet, nothing to check"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
           persist-credentials: false
 
       - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run actionlint
         run: actionlint

--- a/.github/workflows/release-typo3.yml
+++ b/.github/workflows/release-typo3.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Set release comment
         id: get-comment
-        run: echo "comment=See release notes at ${{ needs.release.outputs.release-notes-url }}" >> $GITHUB_OUTPUT
+        run: echo "comment=See release notes at ${{ needs.release.outputs.release-notes-url }}" >> "$GITHUB_OUTPUT"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,64 @@
+# Every ignore below silences a real, currently-open finding that is already
+# tracked in its own issue. None of these are dismissed as non-issues: fixing
+# them means changing behaviour for every consumer of the affected workflow,
+# and issue #47 deliberately sequences all consumer-visible changes behind a
+# freeze tag rather than letting them land one at a time on `main`. As each
+# tracked issue lands, remove its entry here so this file always reflects
+# what is genuinely still open, not a permanent allowlist.
+
+rules:
+  unpinned-uses:
+    ignore:
+      # Third-party actions pinned to a mutable tag instead of a commit SHA.
+      # Tracked in #32.
+      - cgl-test.yml
+      - cgl.yml
+      - release-typo3.yml
+      - release.yml
+      - scorecard.yml
+      - security.yml
+      - tests-php.yml
+      - tests-typo3.yml
+      - tests.yml
+
+  artipacked:
+    ignore:
+      # `actions/checkout` without `persist-credentials: false`. Tracked in
+      # #41, which adds this repository-wide as part of the permissions
+      # baseline.
+      - cgl-test.yml
+      - cgl.yml
+      - release-typo3.yml
+      - release.yml
+      - security.yml
+      - tests-php.yml
+      - tests-typo3.yml
+      - tests.yml
+
+  template-injection:
+    ignore:
+      # `${{ }}` expressions interpolated directly into a `run:` block
+      # instead of being passed through `env:`. Tracked in #31.
+      - release.yml
+      - release-typo3.yml
+
+  archived-uses:
+    ignore:
+      # `paambaati/codeclimate-action` is archived upstream (confirmed via
+      # the GitHub API, last push 2025-07-23). Tracked in #28, which already
+      # covers this workflow's CodeClimate step for an unrelated reason (the
+      # secret it depends on was never actually wired up) and needs to
+      # additionally decide whether to keep, replace, or drop CodeClimate
+      # reporting given the upstream action will not receive further fixes.
+      - tests-php.yml
+      - tests-typo3.yml
+      - tests.yml
+
+  superfluous-actions:
+    ignore:
+      # `softprops/action-gh-release` duplicates what the `gh` CLI already
+      # does and that CLI is preinstalled on GitHub-hosted runners. Genuine
+      # simplification, but a behaviour-adjacent change to a release
+      # workflow, so it is not scheduled rather than silently taken.
+      - release.yml:30
+      - release-typo3.yml:103


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml`, running `actionlint`, `zizmor` and `shellcheck` on every push to `main` and every pull request. Closes the gap where nine reusable workflows and 130+ consumer call sites had no validation of their own.
- Add `zizmor.yml`, silencing findings that are real but already tracked in their own issue, each with an inline comment explaining why and which issue removes it: `unpinned-uses` (#32), `artipacked` (#41), `template-injection` (#31), `archived-uses` (#28), `superfluous-actions` (not scheduled, noted inline).
- Fix three pre-existing `shellcheck` findings that `actionlint` surfaced in `cgl.yml`, `cgl-test.yml` and `release-typo3.yml` (word-splitting and unquoted redirect target), so the new required check starts green rather than red on day one.

## New findings surfaced while building this, not previously tracked anywhere

- `paambaati/codeclimate-action`, used in `tests-php.yml` and `tests-typo3.yml`, is an **archived** upstream repository (confirmed via the GitHub API, last push 2025-07-23). Noted in `zizmor.yml` and needs a decision in #28: keep, replace, or drop CodeClimate reporting, since an archived action will not receive further fixes.
- `zizmor` flags `softprops/action-gh-release` in both release workflows as redundant with the `gh` CLI already preinstalled on GitHub-hosted runners (`superfluous-actions`). Not fixed here since it changes release-workflow behaviour; noted inline in `zizmor.yml` as not scheduled.
- The template-injection audit found **9 findings across 8 lines**, not the 5 originally catalogued in #31. The three missed lines (`release-typo3.yml:123,135,136`) are in the TER-publish job and follow the same pattern as the ones already listed. #31 needs updating with the full list.

## Sequencing note

`ci.yml` itself is new surface with zero consumer impact, so it is pinned and permissioned to the target baseline from the start rather than deferred behind the freeze in #47. The `zizmor.yml` ignores exist specifically because the *existing* nine workflows are gated behind that freeze; removing an ignore entry is part of the acceptance criteria of the issue it references.

## Changes

- `.github/workflows/ci.yml` - new: actionlint, zizmor, shellcheck, each with its own job, `permissions: {}` baseline, `timeout-minutes`, `concurrency`
- `zizmor.yml` - new: documented, per-issue ignores
- `.github/workflows/cgl.yml`, `.github/workflows/cgl-test.yml` - quote a command substitution instead of relying on word-splitting to conditionally add an argument
- `.github/workflows/release-typo3.yml` - quote `$GITHUB_OUTPUT` in a redirect target

## Test Plan

- [x] Confirm the `ci.yml` run on this PR is green for all three jobs
- [ ] Confirm the `shellcheck` job's guard for a missing `scripts/` directory doesn't matter once #49 merges (it stops being a no-op and actually lints)