### PR TITLE
docs: add the canary repository and exclude it from consumer discovery

### DIFF
--- a/docs/canary.md
+++ b/docs/canary.md
@@ -1,0 +1,23 @@
+# Canary
+
+[`konradmichalik/reusable-github-actions-canary`](https://github.com/konradmichalik/reusable-github-actions-canary), built for [issue #48](https://github.com/konradmichalik/reusable-github-actions/issues/48).
+
+A reusable workflow cannot test the working tree of the repository that defines it (see `docs/actions.md`). Linters (`actionlint`, `zizmor`) answer "is this valid", not "does this still work". The canary is the only pre-release signal for the workflow layer: a throwaway consumer that deliberately stays on `@main`, calls every one of the nine reusable workflows, and is allowed to be red without costing anyone attention, because nobody depends on it.
+
+Excluded on purpose from `docs/inventory.md` and from `scripts/find-consumers.sh`'s output (see the `excluded_repos` list in that script) — pinning the canary would defeat its purpose.
+
+## Before merging a change to a reusable workflow
+
+Point the canary's caller workflows at the branch under test (edit the `@main` refs in `konradmichalik/reusable-github-actions-canary/.github/workflows/*.yml` temporarily, or dispatch with a ref override), run `canary.yml` via `workflow_dispatch`, and confirm it is green before merging. Full detail on what calls what, and why the release path is split into two separate manually-dispatched files rather than one automatic one, is in that repository's own README.
+
+## What the first real run found
+
+Standing up the canary and getting it green surfaced five real things, none of them hypothetical:
+
+1. **`typo3/cms-core` cannot currently be installed as a "highest dependency" for `tests-typo3.yml` or `tests.yml`.** Every published `^12.4`/`^13.4` release is affected by at least one open security advisory, and Composer's audit-blocking behaviour refuses to resolve any of them — `--no-audit` in the workflow's `composer-options` does not disable this, it only suppresses the separate `composer audit` report. Filed as its own issue; this is a live, currently-active break for every real consumer's "highest" lane, not a canary artefact.
+2. **The Coveralls step's missing guard (#29) is not theoretical.** The canary's `tests-php.yml` run failed exactly as that issue predicts: no `if:`, no token, the step just runs and fails (`Failed to download coveralls binary or checksum`).
+3. **`cgl-test.yml`'s integration contract was underdocumented.** `composer cgl lint:composer` invokes a script literally named `cgl`, forwarding its argument, not "the same script with a prefix". Real consumers define this themselves (a working example: `"cgl": "@composer -d Tests/CGL --"`, sandboxing tool versions in a nested `Tests/CGL` project). Worth adding to the README once `cgl.yml`/`cgl-test.yml` are merged per #32/#39, so a new consumer doesn't have to reverse-engineer this from a failure.
+4. **`release-typo3.yml` requires a `packaging_exclude.php` file to exist,** or `tailor create-artefact` hard-fails (`VersionService.php line 220`). Real consumers already have one; it isn't documented anywhere in this repository's own README as a prerequisite.
+5. **`release.yml` and `release-typo3.yml` both work end-to-end** when exercised against a real tag: the first succeeds outright, the second correctly fails only at the final TER-publish step against a deliberately-fake token (a real HTTP 500 from TER's own API, not a local error) — confirming the artefact build, tag validation and GitHub release steps all function correctly before that point.
+
+Items 1 and 2 are tracked as issues. Items 3 and 4 are documentation gaps, worth folding into the README the next time it's touched.

--- a/scripts/find-consumers.sh
+++ b/scripts/find-consumers.sh
@@ -34,11 +34,11 @@ reference_pattern='(konradmichalik|jackd248)/reusable-github-actions'
 
 # Throwaway repositories that intentionally reference this project without
 # being real consumers: the canary (issue #48, always on @main by design)
-# and any scratch spike repository (issue #37 and future spikes). Pinning
-# these would be wrong on two counts: the canary's whole purpose is to stay
-# unpinned, and spike repositories are meant to be archived or deleted, not
-# tracked as ongoing consumers.
-excluded_repos='reusable-github-actions-canary spike-uses-resolution'
+# and any scratch spike repository (issue #37, #43 and future spikes).
+# Pinning these would be wrong on two counts: the canary's whole purpose is
+# to stay unpinned, and spike repositories are meant to be archived or
+# deleted, not tracked as ongoing consumers.
+excluded_repos='reusable-github-actions-canary spike-uses-resolution spike-pages-workflow'
 
 is_excluded() {
   for excluded in $excluded_repos; do

--- a/scripts/find-consumers.sh
+++ b/scripts/find-consumers.sh
@@ -32,11 +32,27 @@ fi
 
 reference_pattern='(konradmichalik|jackd248)/reusable-github-actions'
 
+# Throwaway repositories that intentionally reference this project without
+# being real consumers: the canary (issue #48, always on @main by design)
+# and any scratch spike repository (issue #37 and future spikes). Pinning
+# these would be wrong on two counts: the canary's whole purpose is to stay
+# unpinned, and spike repositories are meant to be archived or deleted, not
+# tracked as ongoing consumers.
+excluded_repos='reusable-github-actions-canary spike-uses-resolution'
+
+is_excluded() {
+  for excluded in $excluded_repos; do
+    [ "$1" = "$excluded" ] && return 0
+  done
+  return 1
+}
+
 for owner in $owners; do
   repos=$(gh repo list "$owner" -L 500 --json name,isArchived --jq '.[] | select(.isArchived==false) | .name')
 
   echo "$repos" | while IFS= read -r repo; do
     [ -z "$repo" ] && continue
+    is_excluded "$repo" && continue
     slug="$owner/$repo"
 
     files=$(gh api "repos/$slug/contents/.github/workflows" --jq '.[]? | select(.type=="file") | select(.name | test("\\.ya?ml$")) | .name' 2>/dev/null) || continue


### PR DESCRIPTION
## Summary

- Stand up [`konradmichalik/reusable-github-actions-canary`](https://github.com/konradmichalik/reusable-github-actions-canary) for #48: a throwaway consumer, deliberately kept on `@main`, that calls all nine reusable workflows this repository offers.
- Exclude it (and the already-archived spike scratch repo) from `scripts/find-consumers.sh`'s output, so a future pin sweep never tries to pin the one repository whose entire purpose is staying unpinned.
- Document it in `docs/canary.md`, including what the first real run found.

## What building it found, on real runs, not by inspection

- **New, high-severity bug, filed as #52:** `tests-typo3.yml` and `tests.yml` cannot install `typo3/cms-core` at all today. Every published `^12.4`/`^13.4` release is currently affected by an open security advisory, and Composer's audit-blocking behaviour refuses to resolve any of them. `--no-audit` in the workflow's own `composer-options` does not disable this. Confirmed live: <https://github.com/konradmichalik/reusable-github-actions-canary/actions/runs/32716380957>. This affects every real consumer's "highest" dependency lane right now, not just the canary.
- **#29 confirmed live, not just predicted:** the unguarded Coveralls step failed exactly as that issue describes on the canary's first real `tests-php.yml` run. Added the run link there.
- **Two undocumented integration requirements**, noted in `docs/canary.md` rather than fixed here (documentation gaps, not workflow bugs): `cgl-test.yml` expects the consumer to define their own `cgl` script that forwards its argument (not "the same script with a prefix"), and `release-typo3.yml` requires a `packaging_exclude.php` file to exist or `tailor create-artefact` hard-fails.
- `release.yml` and `release-typo3.yml` both exercised end-to-end against a real tag on the canary: the former succeeds outright, the latter correctly fails only at the final TER-publish step against a deliberately-fake token (a real HTTP 500 from TER's own API), confirming everything before that point works.
- The "deliberately introduce one breakage" acceptance criterion was run for real: a PSR-12 violation was pushed, both `cgl` and `cgl-test` went red as expected, then reverted.

## Changes

- `docs/canary.md` - new
- `scripts/find-consumers.sh` - excludes `reusable-github-actions-canary` and `spike-uses-resolution` from its output

## Test Plan

No manual verification needed here; the claims above are backed by the linked canary run URLs, which stay live (the canary repo is not archived, it runs daily).