### PR TITLE
feat: add pages.yml for GitHub Pages documentation deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,108 @@
+name: Pages
+
+# Reusable GitHub Pages deployment for a VitePress-based docs/ site. Modelled
+# on three real consumers (db-sync-tool, php-sync-tool, translation-validator)
+# that duplicate the same build-then-deploy shape. A fourth candidate,
+# markdown-annotator, turned out to be a different shape entirely (a static
+# file copy with no npm build and a single job), so it is out of scope here.
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version'
+        required: false
+        default: '22'
+        type: string
+      install-command:
+        description: 'Command to install npm dependencies'
+        required: false
+        default: 'npm ci'
+        type: string
+      build-script:
+        description: 'npm script that builds the docs site'
+        required: false
+        default: 'docs:build'
+        type: string
+      output-dir:
+        description: 'Directory containing the built site, uploaded as the Pages artifact'
+        required: false
+        default: 'docs/.vitepress/dist'
+        type: string
+      copy-paths:
+        description: >-
+          Optional newline-separated "source destination" pairs, copied into
+          the build output after the build script runs and before upload.
+          Each pair becomes `cp -r source destination`.
+        required: false
+        default: ''
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Install dependencies
+        env:
+          INSTALL_COMMAND: ${{ inputs.install-command }}
+        run: $INSTALL_COMMAND
+
+      - name: Build docs
+        env:
+          BUILD_SCRIPT: ${{ inputs.build-script }}
+        run: npm run "$BUILD_SCRIPT"
+
+      - name: Copy additional paths into the build output
+        if: inputs.copy-paths != ''
+        env:
+          COPY_PATHS: ${{ inputs.copy-paths }}
+        run: |
+          while read -r src dest; do
+            [ -z "$src" ] && continue
+            cp -r "$src" "$dest"
+          done <<< "$COPY_PATHS"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ${{ inputs.output-dir }}
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,8 @@ on:
         description: >-
           Optional newline-separated "source destination" pairs, copied into
           the build output after the build script runs and before upload.
-          Each pair becomes `cp -r source destination`.
+          Each destination is relative to `output-dir`: a pair `src dest`
+          becomes `cp -r src <output-dir>/dest`.
         required: false
         default: ''
         type: string
@@ -64,6 +65,7 @@ jobs:
           cache: npm
 
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Install dependencies
@@ -74,16 +76,25 @@ jobs:
       - name: Build docs
         env:
           BUILD_SCRIPT: ${{ inputs.build-script }}
+          # VitePress does not auto-detect a Pages project site's sub-path
+          # the way configure-pages does for some other frameworks. On a
+          # project site (not a custom domain or user/org root site), the
+          # build needs to know it. Read this in docs/.vitepress/config.*
+          # as `base: process.env.PAGES_BASE_PATH || '/'` if the site is not
+          # already served from the domain root.
+          PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
         run: npm run "$BUILD_SCRIPT"
 
       - name: Copy additional paths into the build output
         if: inputs.copy-paths != ''
         env:
           COPY_PATHS: ${{ inputs.copy-paths }}
+          OUTPUT_DIR: ${{ inputs.output-dir }}
         run: |
           while read -r src dest; do
             [ -z "$src" ] && continue
-            cp -r "$src" "$dest"
+            mkdir -p "$OUTPUT_DIR/$(dirname "$dest")"
+            cp -r -- "$src" "$OUTPUT_DIR/$dest"
           done <<< "$COPY_PATHS"
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pages.yml`, a reusable workflow for VitePress-based GitHub Pages deployment, closing #43.
- Modelled on three real consumers (`db-sync-tool`, `php-sync-tool`, `translation-validator`) that duplicate the identical build-then-deploy shape. A fourth candidate, `markdown-annotator`, turned out to be a genuinely different shape (static file copy, no npm, single job) on closer reading; corrected #43's "all four" framing and left it out of scope rather than force-fitting it.
- New surface, so it meets the target bar from day one rather than being grandfathered: SHA-pinned actions, `permissions: {}` at the top with per-job grants, `persist-credentials: false` on the build checkout, and every `${{ inputs.* }}` value that reaches a `run:` block routed through `env:` first (the template-injection shape #31 already flags elsewhere, applied proactively here).
- Verified end to end against a real throwaway consumer, not just linted. Archived rather than deleted, so the run and the deployed page stay live as evidence: <https://github.com/konradmichalik/spike-pages-workflow/actions/runs/32723822040>, <https://konradmichalik.github.io/spike-pages-workflow/>.

## What the verification run found

Two real setup mistakes, neither a bug in `pages.yml`:
- The caller must explicitly grant `contents: read, pages: write, id-token: write`. Without it, the run doesn't fail inside a job, it fails at admission with zero jobs listed (`startup_failure`) — permissions only reduce down the chain, confirmed live rather than assumed.
- `actions/setup-node`'s `cache: npm` needs a committed lockfile, same as `npm ci` itself requires. Real consumers already have one; the scratch repo didn't until this surfaced it.

## Changes

- `.github/workflows/pages.yml` - new

## Test Plan

No manual verification needed here beyond what's already linked above; the claims are backed by the archived run and the still-live deployed page, not by reasoning about the YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable workflow for publishing VitePress documentation sites to GitHub Pages.
  - Supports configurable Node.js versions, dependency installation, build commands, output directories, and post-build file copying.
  - Automatically builds the documentation, uploads the generated site, and deploys it to GitHub Pages.
  - Includes controlled deployment permissions, concurrency management, action version pinning, and job timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->