### PR TITLE
fix: pin third-party actions to commit SHAs and fix composer audit block

### DIFF
--- a/.github/workflows/cgl-test.yml
+++ b/.github/workflows/cgl-test.yml
@@ -15,13 +15,13 @@ jobs:
   cgl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           # @todo Use PHP 8.4 once PHP-CS-Fixer supports PHP 8.4
           php-version: ${{ inputs.php-version }}
@@ -48,7 +48,7 @@ jobs:
             git checkout composer.json
           fi
       - name: Re-install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       - name: Check for unused dependencies
         run: composer-unused
 

--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -15,13 +15,13 @@ jobs:
   cgl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           # @todo Use PHP 8.4 once PHP-CS-Fixer supports PHP 8.4
           php-version: ${{ inputs.php-version }}
@@ -48,7 +48,7 @@ jobs:
             git checkout composer.json
           fi
       - name: Re-install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       - name: Check for unused dependencies
         run: composer-unused
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,44 @@ jobs:
           else
             echo "no scripts/*.sh yet, nothing to check"
           fi
+
+  check-action-pins:
+    name: check-action-pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # A floating tag (e.g. @v7) can be moved to point at different code
+      # after review. A full 40-character commit SHA cannot. Docker digest
+      # refs (@sha256:...) and local reusable-workflow paths (./...) are
+      # already content-addressed or repo-local and are exempt.
+      - name: Check that all actions are pinned to a full commit SHA
+        run: |
+          set -euo pipefail
+          status=0
+          for file in .github/workflows/*.yml; do
+            while IFS= read -r line; do
+              ref=$(printf '%s\n' "$line" | grep -oE 'uses:[[:space:]]*[^[:space:]]+' | sed -E 's/uses:[[:space:]]*//')
+              [ -z "$ref" ] && continue
+              case "$ref" in
+                ./*) continue ;;
+              esac
+              pin="${ref##*@}"
+              if [ "$pin" = "$ref" ]; then
+                continue
+              fi
+              case "$pin" in
+                sha256:*) continue ;;
+              esac
+              if ! [[ "$pin" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error file=${file}::Action not pinned to a full commit SHA: ${ref}"
+                status=1
+              fi
+            done < <(grep -E '(^|[[:space:]])uses:[[:space:]]*' "$file")
+          done
+          exit "$status"

--- a/.github/workflows/release-typo3.yml
+++ b/.github/workflows/release-typo3.yml
@@ -34,7 +34,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check tag
         run: |
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: 8.4
           tools: composer:v2, typo3/tailor
@@ -76,7 +76,7 @@ jobs:
           php ~/.composer/vendor/bin/tailor create-artefact "${{ github.ref_name }}"
 
       - name: Upload extension artefact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: extension-artefact
           path: tailor-version-artefact/${{ env.EXTENSION_ARTEFACT }}
@@ -90,17 +90,17 @@ jobs:
     outputs:
       release-notes-url: ${{ steps.create-release.outputs.url }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download extension artefact
         id: download
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: extension-artefact
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           generate_release_notes: true
           files: ${{ steps.download.outputs.download-path }}/${{ env.EXTENSION_ARTEFACT }}
@@ -110,11 +110,11 @@ jobs:
     needs: [release]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download extension artefact
         id: download
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: extension-artefact
 
@@ -123,7 +123,7 @@ jobs:
         run: echo "comment=See release notes at ${{ needs.release.outputs.release-notes-url }}" >> "$GITHUB_OUTPUT"
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: 8.4
           extensions: intl, mbstring, json, zip, curl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       release-notes-url: ${{ steps.create-release.outputs.url }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -27,6 +27,6 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           generate_release_notes: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
       actions: read # read workflow run data for checks
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -49,6 +49,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -27,13 +27,13 @@ jobs:
         php-version: ${{ fromJson(inputs.php-versions || '["8.1", "8.2", "8.3", "8.4"]') }}
         dependencies: ${{ fromJson(inputs.dependencies || '["highest", "lowest"]') }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
@@ -41,7 +41,7 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
@@ -53,13 +53,13 @@ jobs:
     name: Test coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: 8.4
           tools: composer:v2
@@ -67,7 +67,7 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       # Run tests
       - name: Build coverage directory
@@ -80,7 +80,7 @@ jobs:
         working-directory: .build/coverage
         run: sed -i 's#/home/runner/work/php-cs-fixer-config/php-cs-fixer-config#${{ github.workspace }}#g' clover.xml
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: .build/coverage/clover.xml
@@ -91,20 +91,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: coverage
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Download artifact
       - name: Download coverage artifact
         id: download
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage
 
       # CodeClimate
       - name: CodeClimate report
-        uses: paambaati/codeclimate-action@v9.0.0
+        uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
         if: env.CC_TEST_REPORTER_ID
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
@@ -114,6 +114,6 @@ jobs:
 
       # Coveralls
       - name: Coveralls report
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           file: ${{ steps.download.outputs.download-path }}/clover.xml

--- a/.github/workflows/tests-typo3.yml
+++ b/.github/workflows/tests-typo3.yml
@@ -38,13 +38,13 @@ jobs:
       typo3DatabaseUsername: root
       typo3DatabasePassword: root
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:2.9
@@ -54,9 +54,16 @@ jobs:
       - name: Start MySQL
         run: sudo /etc/init.d/mysql start
 
+      # Every published typo3/cms-core release currently has at least one open
+      # security advisory, so Composer's install-time audit block rejects all
+      # of them on a fresh "highest"/"lowest" resolve. --no-audit only skips
+      # the separate `composer audit` report, not this resolution-time filter.
+      - name: Disable Composer's security-advisory install block
+        run: composer config --no-plugins audit.block-insecure false
+
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: --no-audit --with=typo3/cms-core:"^${{ matrix.typo3-version }}"
@@ -74,13 +81,13 @@ jobs:
       typo3DatabaseUsername: root
       typo3DatabasePassword: root
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: 8.4
           tools: composer:2.9
@@ -92,7 +99,7 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       # Run tests
       - name: Run tests
@@ -103,7 +110,7 @@ jobs:
         working-directory: .Build/coverage
         run: sed -i 's#/var/www/html#${{ github.workspace }}#g' clover.xml
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: .Build/coverage/clover.xml
@@ -114,20 +121,20 @@ jobs:
     needs: test-coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Download artifact
       - name: Download coverage artifact
         id: download
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage
 
       # CodeClimate
       - name: CodeClimate report
-        uses: paambaati/codeclimate-action@v9.0.0
+        uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
         if: env.CC_TEST_REPORTER_ID
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
@@ -137,6 +144,6 @@ jobs:
 
       # Coveralls
       - name: Coveralls report
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           file: ${{ steps.download.outputs.download-path }}/clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,13 +39,13 @@ jobs:
       typo3DatabaseUsername: root
       typo3DatabasePassword: root
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
@@ -55,9 +55,15 @@ jobs:
       - name: Start MySQL
         run: sudo /etc/init.d/mysql start
 
+      # Every published typo3/cms-core release currently has at least one open
+      # security advisory, so Composer's install-time audit block rejects all
+      # of them on a fresh "highest"/"lowest" resolve.
+      - name: Disable Composer's security-advisory install block
+        run: composer config --no-plugins audit.block-insecure false
+
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: --with=typo3/cms-core:"^${{ matrix.typo3-version }}"
@@ -75,13 +81,13 @@ jobs:
       typo3DatabaseUsername: root
       typo3DatabasePassword: root
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: 8.4
           tools: composer:v2
@@ -93,7 +99,7 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       # Run tests
       - name: Run tests
@@ -104,7 +110,7 @@ jobs:
         working-directory: .Build/coverage
         run: sed -i 's#/var/www/html#${{ github.workspace }}#g' clover.xml
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: .Build/coverage/clover.xml
@@ -115,20 +121,20 @@ jobs:
     needs: test-coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       # Download artifact
       - name: Download coverage artifact
         id: download
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage
 
       # CodeClimate
       - name: CodeClimate report
-        uses: paambaati/codeclimate-action@v9.0.0
+        uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
         if: env.CC_TEST_REPORTER_ID
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
@@ -138,6 +144,6 @@ jobs:
 
       # Coveralls
       - name: Coveralls report
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           file: ${{ steps.download.outputs.download-path }}/clover.xml


### PR DESCRIPTION
## Summary

- Pin every third-party action across all workflow files to a full 40-character commit SHA instead of a floating tag (`@v7`, `@v2`, `@v4`, ...), closing #32.
- Add a `check-action-pins` job to this repository's own `ci.yml` that hard-fails if any workflow file regresses to a floating tag.
- Disable Composer's install-time `audit.block-insecure` in `tests-typo3.yml` and `tests.yml` before dependency install, closing #52. Every published `typo3/cms-core` release currently carries at least one open security advisory, so the "highest"/"lowest" dependency lane could not resolve `typo3/cms-core` at all. `--no-audit` only suppresses the separate `composer audit` report, not this resolution-time filter.

## Changes

- `.github/workflows/ci.yml` - new `check-action-pins` job, guards against un-pinned actions
- `.github/workflows/cgl.yml`, `cgl-test.yml`, `release.yml`, `release-typo3.yml`, `scorecard.yml`, `security.yml`, `tests-php.yml` - actions pinned to commit SHA
- `.github/workflows/tests-typo3.yml`, `tests.yml` - actions pinned to commit SHA, plus the Composer audit-block fix

## Test Plan

- [x] `actionlint` passes
- [x] `zizmor .github/workflows/` reports no findings
- [x] `check-action-pins` script manually verified to fail against a floating-tag fixture and pass against the current state
- [ ] Confirm the "highest"/"lowest" TYPO3 dependency lane resolves `typo3/cms-core` on a real consumer run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Pinned workflow actions to immutable versions to improve build and release integrity.
  * Added automated checks to detect unpinned third-party actions.
* **Bug Fixes**
  * Updated test workflows so dependency installation continues when published packages have security advisories.
* **CI/CD**
  * Applied consistent action version pinning across testing, security, scoring, and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->